### PR TITLE
Logs better

### DIFF
--- a/README.md
+++ b/README.md
@@ -327,6 +327,23 @@ We use it for the control container because it needs to be available early to gi
 
 Be careful, and make sure you have a similar low-level use case before reaching for host containers.
 
+### Logs
+
+Using the admin container, you can obtain a tarball of logs using `logdog`. SSH to the Bottlerocket host, then run:
+
+```bash
+sudo sheltie
+logdog
+```
+
+This will write a file to `/tmp/bottlerocket-logs.tar.gz`. You can use SSH to retrieve the file. Once you have exited from the Bottlerocket host, run:
+
+```bash
+ssh -i the-key.pem \
+    ec2-user@$BOTTLEROCKET_IP \
+    "cat /.bottlerocket/rootfs/tmp/bottlerocket-logs.tar.gz" > bottlerocket-logs.tar.gz
+```
+
 ## Details
 
 ### Security

--- a/README.md
+++ b/README.md
@@ -344,6 +344,8 @@ ssh -i the-key.pem \
     "cat /.bottlerocket/rootfs/tmp/bottlerocket-logs.tar.gz" > bottlerocket-logs.tar.gz
 ```
 
+For a list of what is collected, see the logdog [README](sources/logdog/README.md)
+
 ## Details
 
 ### Security

--- a/packages/os/Cargo.toml
+++ b/packages/os/Cargo.toml
@@ -13,6 +13,7 @@ source-groups = [
     "growpart",
     "updater",
     "webpki-roots-shim",
+    "logdog",
     "models",
     "preinit",
 ]

--- a/packages/os/os.spec
+++ b/packages/os/os.spec
@@ -130,6 +130,11 @@ Summary: Bottlerocket updater CLI
 %description -n %{_cross_os}updog
 not much what's up with you
 
+%package -n %{_cross_os}logdog
+Summary: Bottlerocket log extractor
+%description -n %{_cross_os}logdog
+use logdog to extract logs from the Bottlerocket host
+
 %package -n %{_cross_os}preinit
 Summary: Bottlerocket pre-init system setup
 %description -n %{_cross_os}preinit
@@ -162,6 +167,7 @@ mkdir bin
     -p migrator \
     -p signpost \
     -p updog \
+    -p logdog \
     -p growpart \
     -p laika \
     %{nil}
@@ -183,7 +189,7 @@ for p in \
   thar-be-settings servicedog host-containers \
   storewolf settings-committer \
   migrator \
-  signpost updog ;
+  signpost updog logdog;
 do
   install -p -m 0755 ${HOME}/.cache/%{__cargo_target}/release/${p} %{buildroot}%{_cross_bindir}
 done
@@ -313,6 +319,9 @@ install -p -m 0644 %{S:201} %{buildroot}%{_cross_tmpfilesdir}/host-containers.co
 %{_cross_datadir}/updog
 %dir %{_cross_templatedir}
 %{_cross_templatedir}/updog-toml
+
+%files -n %{_cross_os}logdog
+%{_cross_bindir}/logdog
 
 %files -n %{_cross_os}preinit
 %{_cross_sbindir}/preinit

--- a/packages/release/release.spec
+++ b/packages/release/release.spec
@@ -57,6 +57,7 @@ Requires: %{_cross_os}systemd
 Requires: %{_cross_os}thar-be-settings
 Requires: %{_cross_os}migration
 Requires: %{_cross_os}updog
+Requires: %{_cross_os}logdog
 Requires: %{_cross_os}util-linux
 Requires: %{_cross_os}preinit
 Requires: %{_cross_os}wicked

--- a/sources/Cargo.lock
+++ b/sources/Cargo.lock
@@ -241,6 +241,11 @@ dependencies = [
 ]
 
 [[package]]
+name = "adler32"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
 name = "aho-corasick"
 version = "0.7.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -607,6 +612,14 @@ dependencies = [
 ]
 
 [[package]]
+name = "crc32fast"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "cfg-if 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "crossbeam-utils"
 version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -837,6 +850,17 @@ dependencies = [
  "libc 0.2.67 (registry+https://github.com/rust-lang/crates.io-index)",
  "redox_syscall 0.1.56 (registry+https://github.com/rust-lang/crates.io-index)",
  "winapi 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "flate2"
+version = "1.0.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "cfg-if 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)",
+ "crc32fast 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.67 (registry+https://github.com/rust-lang/crates.io-index)",
+ "miniz_oxide 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -1302,6 +1326,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "logdog"
+version = "0.1.0"
+dependencies = [
+ "cargo-readme 3.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "flate2 1.0.14 (registry+https://github.com/rust-lang/crates.io-index)",
+ "snafu 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tar 0.4.26 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "loopdev"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1394,6 +1428,14 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "mime 0.3.16 (registry+https://github.com/rust-lang/crates.io-index)",
  "unicase 2.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "miniz_oxide"
+version = "0.3.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "adler32 1.0.4 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -2367,6 +2409,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "tar"
+version = "0.4.26"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "filetime 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.67 (registry+https://github.com/rust-lang/crates.io-index)",
+ "redox_syscall 0.1.56 (registry+https://github.com/rust-lang/crates.io-index)",
+ "xattr 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "tempdir"
 version = "0.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2910,6 +2963,14 @@ dependencies = [
  "winapi-build 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
+[[package]]
+name = "xattr"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "libc 0.2.67 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
 [metadata]
 "checksum actix-codec 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "09e55f0a5c2ca15795035d90c46bd0e73a5123b72f68f12596d6ba5282051380"
 "checksum actix-connect 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)" = "c95cc9569221e9802bf4c377f6c18b90ef10227d787611decf79fd47d2a8e76c"
@@ -2925,6 +2986,7 @@ dependencies = [
 "checksum actix-utils 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)" = "fcf8f5631bf01adec2267808f00e228b761c60c0584cc9fa0b5364f41d147f4e"
 "checksum actix-web 2.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "3158e822461040822f0dbf1735b9c2ce1f95f93b651d7a7aded00b1efbb1f635"
 "checksum actix-web-codegen 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "4f00371942083469785f7e28c540164af1913ee7c96a4534acb9cea92c39f057"
+"checksum adler32 1.0.4 (registry+https://github.com/rust-lang/crates.io-index)" = "5d2e7343e7fc9de883d1b0341e0b13970f764c14101234857d2ddafa1cb1cac2"
 "checksum aho-corasick 0.7.9 (registry+https://github.com/rust-lang/crates.io-index)" = "d5e63fd144e18ba274ae7095c0197a870a7b9468abc801dd62f190d80817d2ec"
 "checksum ansi_term 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ee49baf6cb617b853aa8d93bf420db2383fab46d314482ca2803b40d5fde979b"
 "checksum anyhow 1.0.26 (registry+https://github.com/rust-lang/crates.io-index)" = "7825f6833612eb2414095684fcf6c635becf3ce97fe48cf6421321e93bfbd53c"
@@ -2964,6 +3026,7 @@ dependencies = [
 "checksum core-foundation 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "57d24c7a13c43e870e37c1556b74555437870a04514f7685f5b354e090567171"
 "checksum core-foundation-sys 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "b3a71ab494c0b5b860bdc8407ae08978052417070c2ced38573a9157ad75b8ac"
 "checksum crc 1.8.1 (registry+https://github.com/rust-lang/crates.io-index)" = "d663548de7f5cca343f1e0a48d14dcfb0e9eb4e079ec58883b7251539fa10aeb"
+"checksum crc32fast 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ba125de2af0df55319f41944744ad91c71113bf74a4646efff39afe1f6842db1"
 "checksum crossbeam-utils 0.7.2 (registry+https://github.com/rust-lang/crates.io-index)" = "c3c7c73a2d1e9fc0886a08b93e98eb643461230d5f1925e4036204d5f2e261a8"
 "checksum ct-logs 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)" = "4d3686f5fa27dbc1d76c751300376e167c5a43387f44bb451fd1c24776e49113"
 "checksum darling 0.10.2 (registry+https://github.com/rust-lang/crates.io-index)" = "0d706e75d87e35569db781a9b5e2416cff1236a47ed380831f959382ccd5f858"
@@ -2988,6 +3051,7 @@ dependencies = [
 "checksum failure_derive 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)" = "0bc225b78e0391e4b8683440bf2e63c2deeeb2ce5189eab46e2b68c6d3725d08"
 "checksum fake-simd 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "e88a8acf291dafb59c2d96e8f59828f3838bb1a70398823ade51a84de6a6deed"
 "checksum filetime 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)" = "1ff6d4dab0aa0c8e6346d46052e93b13a16cf847b54ed357087c35011048cc7d"
+"checksum flate2 1.0.14 (registry+https://github.com/rust-lang/crates.io-index)" = "2cfff41391129e0a856d6d822600b8d71179d46879e310417eb9c762eb178b42"
 "checksum fnv 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)" = "2fad85553e09a6f881f739c29f0b00b0f01357c743266d478b68951ce23285f3"
 "checksum fuchsia-cprng 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "a06f77d526c1a601b7c4cdd98f54b5eaabffc14d5f2f0296febdc7f357c6d3ba"
 "checksum fuchsia-zircon 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)" = "2e9763c69ebaae630ba35f74888db465e49e259ba1bc0eda7d06f4a067615d82"
@@ -3046,6 +3110,7 @@ dependencies = [
 "checksum memchr 2.3.3 (registry+https://github.com/rust-lang/crates.io-index)" = "3728d817d99e5ac407411fa471ff9800a778d88a24685968b36824eaf4bee400"
 "checksum mime 0.3.16 (registry+https://github.com/rust-lang/crates.io-index)" = "2a60c7ce501c71e03a9c9c0d35b861413ae925bd979cc7a4e30d060069aaac8d"
 "checksum mime_guess 2.0.3 (registry+https://github.com/rust-lang/crates.io-index)" = "2684d4c2e97d99848d30b324b00c8fcc7e5c897b7cbb5819b09e7c90e8baf212"
+"checksum miniz_oxide 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)" = "aa679ff6578b1cddee93d7e82e263b94a575e0bfced07284eb0c037c1d2416a5"
 "checksum mio 0.6.21 (registry+https://github.com/rust-lang/crates.io-index)" = "302dec22bcf6bae6dfb69c647187f4b4d0fb6f535521f7bc022430ce8e12008f"
 "checksum mio-uds 0.6.7 (registry+https://github.com/rust-lang/crates.io-index)" = "966257a94e196b11bb43aca423754d87429960a768de9414f3691d6957abf125"
 "checksum miow 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "8c1f2f3b1cf331de6896aabf6e9d55dca90356cc9960cca7eaaf408a355ae919"
@@ -3137,6 +3202,7 @@ dependencies = [
 "checksum syn-mid 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)" = "7be3539f6c128a931cf19dcee741c1af532c7fd387baa739c03dd2e96479338a"
 "checksum synstructure 0.12.3 (registry+https://github.com/rust-lang/crates.io-index)" = "67656ea1dc1b41b1451851562ea232ec2e5a80242139f7e679ceccfb5d61f545"
 "checksum sys-mount 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "62f5703caf67c45ad3450104001b4620a605e9def0cef13dde3c9add23f73cee"
+"checksum tar 0.4.26 (registry+https://github.com/rust-lang/crates.io-index)" = "b3196bfbffbba3e57481b6ea32249fbaf590396a52505a2615adbb79d9d826d3"
 "checksum tempdir 0.3.7 (registry+https://github.com/rust-lang/crates.io-index)" = "15f2b5fb00ccdf689e0149d1b1b3c03fead81c2b37735d812fa8bddbbf41b6d8"
 "checksum tempfile 3.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "7a6e24d9338a0a5be79593e2fa15a648add6138caa803e2d5bc782c371732ca9"
 "checksum term 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)" = "c0863a3345e70f61d613eab32ee046ccd1bcc5f9105fe402c61fcd0c13eeb8b5"
@@ -3191,3 +3257,4 @@ dependencies = [
 "checksum winreg 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)" = "b2986deb581c4fe11b621998a5e53361efe6b48a151178d0cd9eeffa4dc6acc9"
 "checksum winutil 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "7daf138b6b14196e3830a588acf1e86966c694d3e8fb026fb105b8b5dca07e6e"
 "checksum ws2_32-sys 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "d59cefebd0c892fa2dd6de581e937301d8552cb44489cdff035c6187cb63fa5e"
+"checksum xattr 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "244c3741f4240ef46274860397c7c74e50eb23624996930e484c16679633a54c"

--- a/sources/Cargo.lock
+++ b/sources/Cargo.lock
@@ -1333,6 +1333,7 @@ dependencies = [
  "flate2 1.0.14 (registry+https://github.com/rust-lang/crates.io-index)",
  "snafu 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "tar 0.4.26 (registry+https://github.com/rust-lang/crates.io-index)",
+ "uuid 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -2737,6 +2738,14 @@ dependencies = [
 ]
 
 [[package]]
+name = "uuid"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "rand 0.7.3 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "vec_map"
 version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3230,6 +3239,7 @@ dependencies = [
 "checksum unicode-xid 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "826e7639553986605ec5979c7dd957c7895e93eabed50ab2ffa7f6128a75097c"
 "checksum untrusted 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "60369ef7a31de49bcb3f6ca728d4ba7300d9a1658f94c727d4cab8c8d9f4aece"
 "checksum url 2.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "829d4a8476c35c9bf0bbce5a3b23f4106f79728039b726d292bb93bc106787cb"
+"checksum uuid 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)" = "9fde2f6a4bea1d6e007c4ad38c6839fa71cbb63b6dbf5b595aa38dc9b1093c11"
 "checksum vec_map 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)" = "05c78687fb1a80548ae3250346c3db86a80a7cdd77bda190189f2d0a0987c81a"
 "checksum version_check 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "914b1a6776c4c929a602fafd8bc742e06365d4bcbe48c30f9cca5824f70dc9dd"
 "checksum version_check 0.9.1 (registry+https://github.com/rust-lang/crates.io-index)" = "078775d0255232fb988e6fccf26ddc9d1ac274299aaedcedce21c6f72cc533ce"

--- a/sources/Cargo.toml
+++ b/sources/Cargo.toml
@@ -22,6 +22,8 @@ members = [
 
     "growpart",
 
+    "logdog",
+
     "models",
 
     "preinit/laika",

--- a/sources/deny.toml
+++ b/sources/deny.toml
@@ -19,7 +19,7 @@ allow = [
     "MIT",
     "OpenSSL",
     "Unlicense",
-    #"Zlib",  # OK but currently unused; commenting to prevent warning
+    "Zlib"
 ]
 
 exceptions = [

--- a/sources/logdog/Cargo.toml
+++ b/sources/logdog/Cargo.toml
@@ -13,3 +13,6 @@ tar = "0.4"
 
 [build-dependencies]
 cargo-readme = "3.1"
+
+[dev-dependencies]
+uuid = { version = "0.8.1", features = [ "v4" ] }

--- a/sources/logdog/Cargo.toml
+++ b/sources/logdog/Cargo.toml
@@ -1,0 +1,15 @@
+[package]
+name = "logdog"
+version = "0.1.0"
+authors = ["Matt Briggs <brigmatt@amazon.com>"]
+license = "Apache-2.0 OR MIT"
+edition = "2018"
+publish = false
+
+[dependencies]
+flate2 = "1.0"
+snafu = "0.6"
+tar = "0.4"
+
+[build-dependencies]
+cargo-readme = "3.1"

--- a/sources/logdog/README.md
+++ b/sources/logdog/README.md
@@ -13,15 +13,6 @@ $ logdog
 logs are at: /tmp/bottlerocket-logs.tar.gz
 ```
 
-### TODO
-
- [x] journalctl-list-boots is instead errors
- [x] dmesg not working
- [x] iptables missing
- [ ] customer readme instructions ssh
- [ ] customer readme instructions ssm
- [ ] unit tests
-
 ## Colophon
 
 This text was generated from `README.tpl` using [cargo-readme](https://crates.io/crates/cargo-readme), and includes the rustdoc from `src/main.rs`.

--- a/sources/logdog/README.md
+++ b/sources/logdog/README.md
@@ -13,6 +13,15 @@ $ logdog
 logs are at: /tmp/bottlerocket-logs.tar.gz
 ```
 
+### TODO
+
+ [x] journalctl-list-boots is instead errors
+ [x] dmesg not working
+ [x] iptables missing
+ [ ] customer readme instructions ssh
+ [ ] customer readme instructions ssm
+ [ ] unit tests
+
 ## Colophon
 
 This text was generated from `README.tpl` using [cargo-readme](https://crates.io/crates/cargo-readme), and includes the rustdoc from `src/main.rs`.

--- a/sources/logdog/README.md
+++ b/sources/logdog/README.md
@@ -1,0 +1,18 @@
+# logdog
+
+Current version: 0.1.0
+
+## Introduction
+
+`logdog` is a program that gathers logs from various places on a Bottlerocket host and combines them
+into a tarball for easy export.
+
+Usage example:
+```bash
+$ logdog
+logs are at: /tmp/bottlerocket-logs.tar.gz
+```
+
+## Colophon
+
+This text was generated from `README.tpl` using [cargo-readme](https://crates.io/crates/cargo-readme), and includes the rustdoc from `src/main.rs`.

--- a/sources/logdog/README.md
+++ b/sources/logdog/README.md
@@ -13,6 +13,24 @@ $ logdog
 logs are at: /tmp/bottlerocket-logs.tar.gz
 ```
 
+#### Logs Collected
+
+`logdog` will aggregate the following information:
+
+ * a copy of os-release to tell us the version and build of Bottlerocket
+ * a list of boots that journalctl knows about
+ * errors from journalctl
+ * all log lines from journalctl
+ * signpost status to tell us the status of grub and the boot partitions
+ * Bottlerocket settings using the apiclient
+ * networking status from wicked
+ * configuration info from containerd
+ * the status of kubelet and other kube processes from systemctl
+ * the kernel message buffer with dmesg
+ * firewall filtering information from iptables
+ * firewall nat information from iptables.
+
+
 ## Colophon
 
 This text was generated from `README.tpl` using [cargo-readme](https://crates.io/crates/cargo-readme), and includes the rustdoc from `src/main.rs`.

--- a/sources/logdog/README.md
+++ b/sources/logdog/README.md
@@ -8,7 +8,7 @@ Current version: 0.1.0
 into a tarball for easy export.
 
 Usage example:
-```bash
+```rust
 $ logdog
 logs are at: /tmp/bottlerocket-logs.tar.gz
 ```

--- a/sources/logdog/README.tpl
+++ b/sources/logdog/README.tpl
@@ -1,0 +1,9 @@
+# {{crate}}
+
+Current version: {{version}}
+
+{{readme}}
+
+## Colophon
+
+This text was generated from `README.tpl` using [cargo-readme](https://crates.io/crates/cargo-readme), and includes the rustdoc from `src/main.rs`.

--- a/sources/logdog/build.rs
+++ b/sources/logdog/build.rs
@@ -1,0 +1,32 @@
+// Automatically generate README.md from rustdoc.
+
+use std::env;
+use std::fs::File;
+use std::io::Write;
+use std::path::PathBuf;
+
+fn main() {
+    // Check for environment variable "SKIP_README". If it is set,
+    // skip README generation
+    if env::var_os("SKIP_README").is_some() {
+        return;
+    }
+
+    let mut source = File::open("src/main.rs").unwrap();
+    let mut template = File::open("README.tpl").unwrap();
+
+    let content = cargo_readme::generate_readme(
+        &PathBuf::from("."), // root
+        &mut source,         // source
+        Some(&mut template), // template
+        // The "add x" arguments don't apply when using a template.
+        true,  // add title
+        false, // add badges
+        false, // add license
+        true,  // indent headings
+    )
+    .unwrap();
+
+    let mut readme = File::create("README.md").unwrap();
+    readme.write_all(content.as_bytes()).unwrap();
+}

--- a/sources/logdog/src/create_tarball.rs
+++ b/sources/logdog/src/create_tarball.rs
@@ -9,13 +9,55 @@ use flate2::Compression;
 use snafu::ResultExt;
 use tar;
 
-pub fn create_tarball(tempdir: &PathBuf, outfile: &PathBuf) -> crate::error::Result<()> {
+// Creates a tarball with all the contents of directory `dir`.
+// Outputs as file to `outfile`.
+pub(crate) fn create_tarball(dir: &PathBuf, outfile: &PathBuf) -> crate::error::Result<()> {
     let tarfile = File::create(outfile).context(crate::error::FileError {
         path: outfile.to_str().unwrap(),
     })?;
     let encoder = GzEncoder::new(tarfile, Compression::default());
     let mut tarball = tar::Builder::new(encoder);
     tarball
-        .append_dir_all(crate::TARBALL_DIRNAME, tempdir.to_str().unwrap())
+        .append_dir_all(crate::TARBALL_DIRNAME, dir.to_str().unwrap())
         .context(crate::error::IoError {})
+}
+
+#[cfg(test)]
+mod tests {
+    use std::path::Path;
+
+    use uuid::Uuid;
+
+    use super::*;
+    use std::io::Write;
+    use flate2::read::GzDecoder;
+    use tar::Archive;
+
+    #[test]
+    fn test() {
+        let inpath = std::env::temp_dir().join(Uuid::new_v4().to_string());
+        let _indir = crate::TempDir::new(inpath.clone()).unwrap();
+        let outpath = std::env::temp_dir().join(Uuid::new_v4().to_string());
+        let outdir = crate::TempDir::new(outpath).unwrap();
+        let outfilepath = outdir.path().join("somefile.tar.gz");
+        let mut file = File::create(inpath.join("hello.txt")).unwrap();
+        file.write_all(b"Hello World!").unwrap();
+        drop(file);
+        create_tarball(&inpath, &outfilepath).unwrap();
+        assert!(Path::new(&outfilepath).is_file());
+        let tar_gz = File::open(outfilepath).unwrap();
+        let tar = GzDecoder::new(tar_gz);
+        let mut archive = Archive::new(tar);
+        let mut entries = archive.entries().unwrap();
+
+        let entry = entries.next().unwrap().unwrap();
+        let actual_path = PathBuf::from(entry.path().unwrap());
+        let expected_path = PathBuf::from(crate::TARBALL_DIRNAME);
+        assert!(actual_path == expected_path);
+
+        let entry = entries.next().unwrap().unwrap();
+        let actual_path = PathBuf::from(entry.path().unwrap());
+        let expected_path = PathBuf::from(crate::TARBALL_DIRNAME).join("hello.txt");
+        assert!(actual_path == expected_path);
+    }
 }

--- a/sources/logdog/src/create_tarball.rs
+++ b/sources/logdog/src/create_tarball.rs
@@ -4,14 +4,18 @@
 use std::fs::File;
 use std::path::PathBuf;
 
-use flate2::Compression;
 use flate2::write::GzEncoder;
+use flate2::Compression;
 use snafu::ResultExt;
 use tar;
 
 pub fn create_tarball(tempdir: &PathBuf, outfile: &PathBuf) -> crate::error::Result<()> {
-    let tarfile = File::create(outfile).context(crate::error::FileError { path: outfile.to_str().unwrap() })?;
+    let tarfile = File::create(outfile).context(crate::error::FileError {
+        path: outfile.to_str().unwrap(),
+    })?;
     let encoder = GzEncoder::new(tarfile, Compression::default());
     let mut tarball = tar::Builder::new(encoder);
-    tarball.append_dir_all(crate::TARBALL_DIRNAME, tempdir.to_str().unwrap()).context(crate::error::IoError {})
+    tarball
+        .append_dir_all(crate::TARBALL_DIRNAME, tempdir.to_str().unwrap())
+        .context(crate::error::IoError {})
 }

--- a/sources/logdog/src/create_tarball.rs
+++ b/sources/logdog/src/create_tarball.rs
@@ -29,8 +29,8 @@ mod tests {
     use uuid::Uuid;
 
     use super::*;
-    use std::io::Write;
     use flate2::read::GzDecoder;
+    use std::io::Write;
     use tar::Archive;
 
     #[test]

--- a/sources/logdog/src/create_tarball.rs
+++ b/sources/logdog/src/create_tarball.rs
@@ -1,0 +1,17 @@
+// Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
+use std::fs::File;
+use std::path::PathBuf;
+
+use flate2::Compression;
+use flate2::write::GzEncoder;
+use snafu::ResultExt;
+use tar;
+
+pub fn create_tarball(tempdir: &PathBuf, outfile: &PathBuf) -> crate::error::Result<()> {
+    let tarfile = File::create(outfile).context(crate::error::FileError { path: outfile.to_str().unwrap() })?;
+    let encoder = GzEncoder::new(tarfile, Compression::default());
+    let mut tarball = tar::Builder::new(encoder);
+    tarball.append_dir_all(crate::TARBALL_DIRNAME, tempdir.to_str().unwrap()).context(crate::error::IoError {})
+}

--- a/sources/logdog/src/create_tarball.rs
+++ b/sources/logdog/src/create_tarball.rs
@@ -34,7 +34,7 @@ mod tests {
     use tar::Archive;
 
     #[test]
-    fn test() {
+    fn tarball_test() {
         let inpath = std::env::temp_dir().join(Uuid::new_v4().to_string());
         let _indir = crate::TempDir::new(inpath.clone()).unwrap();
         let outpath = std::env::temp_dir().join(Uuid::new_v4().to_string());

--- a/sources/logdog/src/error.rs
+++ b/sources/logdog/src/error.rs
@@ -9,10 +9,6 @@ use snafu::{Snafu, Backtrace};
 #[derive(Debug, Snafu)]
 #[snafu(visibility = "pub")]
 pub enum Error {
-    #[snafu(display("Error: '{}'", message))]
-    ErrorMessage {
-        message: String,
-    },
     #[snafu(display("File error '{}': {}", path.to_string_lossy(), source))]
     FileError {
         source: io::Error,

--- a/sources/logdog/src/error.rs
+++ b/sources/logdog/src/error.rs
@@ -4,7 +4,7 @@
 use std::io;
 use std::path::PathBuf;
 
-use snafu::{Snafu, Backtrace};
+use snafu::{Backtrace, Snafu};
 
 #[derive(Debug, Snafu)]
 #[snafu(visibility = "pub")]

--- a/sources/logdog/src/error.rs
+++ b/sources/logdog/src/error.rs
@@ -1,0 +1,29 @@
+// Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
+use std::io;
+use std::path::PathBuf;
+
+use snafu::{Snafu, Backtrace};
+
+#[derive(Debug, Snafu)]
+#[snafu(visibility = "pub")]
+pub enum Error {
+    #[snafu(display("Error: '{}'", message))]
+    ErrorMessage {
+        message: String,
+    },
+    #[snafu(display("File error '{}': {}", path.to_string_lossy(), source))]
+    FileError {
+        source: io::Error,
+        path: PathBuf,
+        backtrace: Backtrace,
+    },
+    #[snafu(display("IO error: {}", source))]
+    IoError {
+        source: io::Error,
+        backtrace: Backtrace,
+    },
+}
+
+pub type Result<T> = std::result::Result<T, Error>;

--- a/sources/logdog/src/exec_to_file.rs
+++ b/sources/logdog/src/exec_to_file.rs
@@ -6,7 +6,7 @@ use std::io::Write;
 use std::path::PathBuf;
 use std::process::{Command, Stdio};
 
-use crate::error::{Result, FileError, IoError};
+use crate::error::{FileError, IoError, Result};
 use snafu::ResultExt;
 
 /// Aggregates the information needed to run a shell command and pipe it to a file.
@@ -21,17 +21,21 @@ impl ExecToFile {
     /// Runs a shell command and pipes its output to a named file in the specified outdir.
     pub(crate) fn run(&self, outdir: &PathBuf) -> Result<()> {
         let opath = outdir.join(self.output_filename);
-        let mut ofile = File::create(&opath)
-            .context(FileError { path: opath.clone() })?;
-        let efile = ofile.try_clone()
-            .context(FileError { path: opath.clone() })?;
-        ofile.write(format!("{:?}\n", self).into_bytes().as_slice())
-            .context(FileError { path: opath.clone() })?;
+        let mut ofile = File::create(&opath).context(FileError {
+            path: opath.clone(),
+        })?;
+        let efile = ofile.try_clone().context(FileError {
+            path: opath.clone(),
+        })?;
+        ofile
+            .write(format!("{:?}\n", self).into_bytes().as_slice())
+            .context(FileError { path: opath })?;
         Command::new(self.command)
             .args(&self.args)
             .stdout(Stdio::from(ofile))
             .stderr(Stdio::from(efile))
-            .spawn().context(IoError {})?
+            .spawn()
+            .context(IoError {})?
             .wait_with_output()
             .context(IoError {})?;
         Ok(())
@@ -39,20 +43,26 @@ impl ExecToFile {
 }
 
 /// Runs a list of commands and pipes all of them into the same outdir. If a command raises an error,
-/// `run_commands` pipes that error to a file and continues without failing or returning the error.
+/// `run_commands` pipes that error to a file and continues without failing.
 pub(crate) fn run_commands(commands: Vec<ExecToFile>, outdir: &PathBuf) -> Result<()> {
     // if a command fails, we will pipe its error here and continue.
     let error_path = outdir.join(crate::ERROR_FILENAME);
-    let mut error_file = File::create(&error_path)
-        .context(FileError { path: error_path.clone() })?;
+    let mut error_file = File::create(&error_path).context(FileError {
+        path: error_path.clone(),
+    })?;
 
     for ex in commands.iter() {
         if let Err(e) = ex.run(&outdir) {
             // ignore the error, but make note of it in the error file.
-            error_file.write(
-                format!("Error running command '{:?}': '{}'\n", ex.clone(), e)
-                    .into_bytes().as_slice()
-            ).context(FileError { path: error_path.clone() })?;
+            error_file
+                .write(
+                    format!("Error running command '{:?}': '{}'\n", ex.clone(), e)
+                        .into_bytes()
+                        .as_slice(),
+                )
+                .context(FileError {
+                    path: error_path.clone(),
+                })?;
         }
     }
     Ok(())

--- a/sources/logdog/src/exec_to_file.rs
+++ b/sources/logdog/src/exec_to_file.rs
@@ -1,0 +1,55 @@
+// Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
+use std::fs::File;
+use std::io::Write;
+use std::path::PathBuf;
+use std::process::{Command, Stdio};
+
+use crate::error::{Result, FileError, IoError};
+use snafu::ResultExt;
+
+#[derive(Debug, Clone)]
+pub(crate) struct ExecToFile {
+    pub command: &'static str,
+    pub args: Vec<&'static str>,
+    pub output_filename: &'static str,
+}
+
+impl ExecToFile {
+    pub(crate) fn run(&self, tempdir: &PathBuf) -> Result<()> {
+        let opath = tempdir.join(self.output_filename);
+        let mut ofile = File::create(&opath)
+            .context(FileError { path: opath.clone() })?;
+        let efile = ofile.try_clone()
+            .context(FileError { path: opath.clone() })?;
+        ofile.write(format!("{:?}\n", self).into_bytes().as_slice())
+            .context(FileError { path: opath.clone() })?;
+        Command::new(self.command)
+            .args(&self.args)
+            .stdout(Stdio::from(ofile))
+            .stderr(Stdio::from(efile))
+            .spawn().context(IoError {})?
+            .wait_with_output()
+            .context(IoError {})?;
+        Ok(())
+    }
+}
+
+pub(crate) fn run_commands(commands: Vec<ExecToFile>, outdir: &PathBuf) -> Result<()> {
+    let error_path = outdir.join(crate::ERROR_FILENAME);
+    let mut error_file = File::create(&error_path)
+        .context(FileError { path: error_path.clone() })?;
+    for ex in commands.iter() {
+        if let Err(e) = ex.run(&outdir) {
+            error_file.write(
+                format!(
+                    "Error running command '{:?}': '{}'\n",
+                    ex.clone(),
+                    e
+                ).into_bytes().as_slice()
+            ).context(FileError { path: error_path.clone() })?;
+        }
+    }
+    Ok(())
+}

--- a/sources/logdog/src/exec_to_file.rs
+++ b/sources/logdog/src/exec_to_file.rs
@@ -9,6 +9,7 @@ use std::process::{Command, Stdio};
 use crate::error::{Result, FileError, IoError};
 use snafu::ResultExt;
 
+/// Aggregates the information needed to run a shell command and pipe it to a file.
 #[derive(Debug, Clone)]
 pub(crate) struct ExecToFile {
     pub command: &'static str,
@@ -17,8 +18,9 @@ pub(crate) struct ExecToFile {
 }
 
 impl ExecToFile {
-    pub(crate) fn run(&self, tempdir: &PathBuf) -> Result<()> {
-        let opath = tempdir.join(self.output_filename);
+    /// Runs a shell command and pipes its output to a named file in the specified outdir.
+    pub(crate) fn run(&self, outdir: &PathBuf) -> Result<()> {
+        let opath = outdir.join(self.output_filename);
         let mut ofile = File::create(&opath)
             .context(FileError { path: opath.clone() })?;
         let efile = ofile.try_clone()
@@ -36,18 +38,20 @@ impl ExecToFile {
     }
 }
 
+/// Runs a list of commands and pipes all of them into the same outdir. If a command raises an error,
+/// `run_commands` pipes that error to a file and continues without failing or returning the error.
 pub(crate) fn run_commands(commands: Vec<ExecToFile>, outdir: &PathBuf) -> Result<()> {
+    // if a command fails, we will pipe its error here and continue.
     let error_path = outdir.join(crate::ERROR_FILENAME);
     let mut error_file = File::create(&error_path)
         .context(FileError { path: error_path.clone() })?;
+
     for ex in commands.iter() {
         if let Err(e) = ex.run(&outdir) {
+            // ignore the error, but make note of it in the error file.
             error_file.write(
-                format!(
-                    "Error running command '{:?}': '{}'\n",
-                    ex.clone(),
-                    e
-                ).into_bytes().as_slice()
+                format!("Error running command '{:?}': '{}'\n", ex.clone(), e)
+                    .into_bytes().as_slice()
             ).context(FileError { path: error_path.clone() })?;
         }
     }

--- a/sources/logdog/src/main.rs
+++ b/sources/logdog/src/main.rs
@@ -17,7 +17,10 @@ logs are at: /tmp/bottlerocket-logs.tar.gz
 
  [x] journalctl-list-boots is instead errors
  [x] dmesg not working
- [ ] iptables missing
+ [x] iptables missing
+ [ ] customer readme instructions ssh
+ [ ] customer readme instructions ssm
+ [ ] unit tests
 */
 
 #![deny(rust_2018_idioms)]
@@ -84,6 +87,7 @@ fn parse_args(args: env::Args) -> PathBuf {
     }
 }
 
+// Runs the bulk of the program's logic, main wraps this.
 fn run_program(output: PathBuf) -> Result<()> {
     let temp_dir_path = env::temp_dir().join(TEMP_SUBDIR_NANE);
     if Path::new(&temp_dir_path).exists() {
@@ -150,6 +154,16 @@ fn create_commands() -> Vec<ExecToFile> {
             command: "dmesg",
             args: vec!["--color=never", "--nopager"],
             output_filename: "dmesg",
+        },
+        ExecToFile {
+            command: "iptables",
+            args: vec!["-nvL", "-t", "filter"],
+            output_filename: "iptables-filter",
+        },
+        ExecToFile {
+            command: "iptables",
+            args: vec!["-nvL", "-t", "nat"],
+            output_filename: "iptables-nat",
         }
     )
 }

--- a/sources/logdog/src/main.rs
+++ b/sources/logdog/src/main.rs
@@ -12,6 +12,24 @@ Usage example:
 $ logdog
 logs are at: /tmp/bottlerocket-logs.tar.gz
 ```
+
+### Logs Collected
+
+`logdog` will aggregate the following information:
+
+ * a copy of os-release to tell us the version and build of Bottlerocket
+ * a list of boots that journalctl knows about
+ * errors from journalctl
+ * all log lines from journalctl
+ * signpost status to tell us the status of grub and the boot partitions
+ * Bottlerocket settings using the apiclient
+ * networking status from wicked
+ * configuration info from containerd
+ * the status of kubelet and other kube processes from systemctl
+ * the kernel message buffer with dmesg
+ * firewall filtering information from iptables
+ * firewall nat information from iptables.
+
 */
 
 #![deny(rust_2018_idioms)]
@@ -96,7 +114,7 @@ fn run_program(output: &PathBuf) -> Result<()> {
 /// Produces the list of commands that we will run on the Bottlerocket host.
 fn create_commands() -> Vec<ExecToFile> {
     vec![
-        // Get a copy of os-release to tell us the version and build of Bottlerocket.
+        // a copy of os-release to tell us the version and build of Bottlerocket.
         ExecToFile {
             command: "cat",
             args: vec!["/etc/os-release"],
@@ -108,7 +126,7 @@ fn create_commands() -> Vec<ExecToFile> {
             args: vec!["--list-boots", "--no-pager"],
             output_filename: "journalctl-list-boots",
         },
-        // Get errors only from journalctl.
+        // Get errors from journalctl.
         ExecToFile {
             command: "journalctl",
             args: vec!["-p", "err", "-a", "--no-pager"],
@@ -132,7 +150,7 @@ fn create_commands() -> Vec<ExecToFile> {
             args: vec!["--method", "GET", "--uri", "/settings"],
             output_filename: "settings.json",
         },
-        // Get networking status with wicked.
+        // Get networking status from wicked.
         ExecToFile {
             command: "wicked",
             args: vec!["show", "all"],
@@ -156,13 +174,13 @@ fn create_commands() -> Vec<ExecToFile> {
             args: vec!["--color=never", "--nopager"],
             output_filename: "dmesg",
         },
-        // Get firewall filtering information with iptables.
+        // Get firewall filtering information from iptables.
         ExecToFile {
             command: "iptables",
             args: vec!["-nvL", "-t", "filter"],
             output_filename: "iptables-filter",
         },
-        // Get firewall nat information with iptables.
+        // Get firewall nat information from iptables.
         ExecToFile {
             command: "iptables",
             args: vec!["-nvL", "-t", "nat"],

--- a/sources/logdog/src/main.rs
+++ b/sources/logdog/src/main.rs
@@ -15,7 +15,7 @@ logs are at: /tmp/bottlerocket-logs.tar.gz
 
 ## TODO
 
- [ ] journalctl-list-boots is instead errors
+ [x] journalctl-list-boots is instead errors
  [x] dmesg not working
  [ ] iptables missing
 */
@@ -108,7 +108,7 @@ fn create_commands() -> Vec<ExecToFile> {
         },
         ExecToFile {
             command: "journalctl",
-            args: vec!["-p", "3", "--no-pager"],
+            args: vec!["--list-boots", "--no-pager"],
             output_filename: "journalctl-list-boots",
         },
         ExecToFile {

--- a/sources/logdog/src/main.rs
+++ b/sources/logdog/src/main.rs
@@ -1,0 +1,168 @@
+// Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
+/*!
+# Introduction
+
+`logdog` is a program that gathers logs from various places on a Bottlerocket host and combines them
+into a tarball for easy export.
+
+Usage example:
+```bash
+$ logdog
+logs are at: /tmp/bottlerocket-logs.tar.gz
+```
+*/
+
+#![deny(rust_2018_idioms)]
+
+mod error;
+mod exec_to_file;
+mod create_tarball;
+mod temp_dir;
+
+use std::fs::remove_dir_all;
+use std::path::{PathBuf, Path};
+use std::{env, process};
+
+use create_tarball::create_tarball;
+use error::{Result, FileError, IoError};
+use exec_to_file::{ExecToFile, run_commands};
+use temp_dir::TempDir;
+
+use snafu::{ErrorCompat, ResultExt};
+
+const TEMP_SUBDIR_NANE: &str = "logdog-temp";
+const OUTPUT_FILENAME: &str = "bottlerocket-logs.tar.gz";
+const ERROR_FILENAME: &str = "logdog.errors";
+const TARBALL_DIRNAME: &str = "bottlerocket-logs";
+
+/// Prints a usage message in the event a bad arg is passed
+fn usage() -> ! {
+    let program_name = env::args().next().unwrap_or_else(|| "program".to_string());
+    eprintln!(
+        r"Usage: {}
+            [ --output PATH file to write zipped logs to ]
+",
+        program_name,
+    );
+    process::exit(2);
+}
+
+/// Prints a more specific message before exiting through usage().
+fn usage_msg(msg: &str) -> ! {
+    eprintln!("{}\n", msg);
+    usage();
+}
+
+/// Parses the command line arguments.
+fn parse_args(args: env::Args) -> PathBuf {
+    let mut output_arg = None;
+    let mut iter = args.skip(1);
+    while let Some(arg) = iter.next() {
+        match arg.as_ref() {
+            "--output" => {
+                output_arg = Some(
+                    iter.next()
+                        .unwrap_or_else(|| usage_msg("Did not give argument to --output")),
+                )
+            }
+
+            _ => usage(),
+        }
+    }
+
+    match output_arg {
+        Some(path) => PathBuf::from(path),
+        None => env::temp_dir().as_path().join(OUTPUT_FILENAME),
+    }
+}
+
+fn run_program(output: PathBuf) -> Result<()> {
+    let temp_dir_path = env::temp_dir().join(TEMP_SUBDIR_NANE);
+    if Path::new(&temp_dir_path).exists() {
+        remove_dir_all(&temp_dir_path)
+            .context(FileError { path: temp_dir_path.clone() })?;
+    }
+    let temp_dir = TempDir::new(temp_dir_path)
+        .context(IoError {})?;
+    run_commands(create_commands(), &temp_dir.path())?;
+    create_tarball(&temp_dir.path(), &output)?;
+    println!("logs are at: {}", output.to_string_lossy());
+    Ok(())
+}
+
+// Produces the list of commands that we will run on the Bottlerocket host.
+fn create_commands() -> Vec<ExecToFile> {
+    vec!(
+        ExecToFile {
+            command: "cat",
+            args: vec!["/etc/os-release"],
+            output_filename: "os-release",
+        },
+        ExecToFile {
+            command: "journalctl",
+            args: vec!["-p", "3", "--no-pager"],
+            output_filename: "journalctl-list-boots",
+        },
+        ExecToFile {
+            command: "journalctl",
+            args: vec!["-p", "err", "-a", "--no-pager"],
+            output_filename: "journalctl.errors",
+        },
+        ExecToFile {
+            command: "journalctl",
+            args: vec!["-a", "--no-pager"],
+            output_filename: "journalctl.log",
+        },
+        ExecToFile {
+            command: "signpost",
+            args: vec!["status"],
+            output_filename: "signpost",
+        },
+        ExecToFile {
+            command: "apiclient",
+            args: vec!["--method", "GET", "--uri", "/settings"],
+            output_filename: "settings.json",
+        },
+        ExecToFile {
+            command: "wicked",
+            args: vec!["show", "all"],
+            output_filename: "wicked",
+        },
+        ExecToFile {
+            command: "containerd",
+            args: vec!["config", "dump"],
+            output_filename: "containerd-config",
+        },
+        ExecToFile {
+            command: "systemctl",
+            args: vec!["status", "kube*", "-l", "--no-pager"],
+            output_filename: "kube-status",
+        },
+        ExecToFile {
+            command: "dmesg",
+            args: vec!["--color", "never", "--nopager"],
+            output_filename: "dmesg",
+        }
+    )
+}
+
+
+fn main() -> ! {
+    let output = parse_args(env::args());
+    process::exit(match run_program(output) {
+        Ok(()) => 0,
+        Err(err) => {
+            eprintln!("{}", err);
+            if let Some(var) = env::var_os("RUST_BACKTRACE") {
+                if var != "0" {
+                    if let Some(backtrace) = err.backtrace() {
+                        eprintln!("\n{:?}", backtrace);
+                    }
+                }
+            }
+            1
+        }
+    })
+}

--- a/sources/logdog/src/main.rs
+++ b/sources/logdog/src/main.rs
@@ -207,7 +207,7 @@ mod tests {
         run_program(&output_filepath).unwrap();
 
         // Open the file and spot check that a couple of expected files exist inside it.
-        // These function will panic if the path is not found in the tarball
+        // This function will panic if the path is not found in the tarball
         let find = |path_to_find: &PathBuf| {
             let tar_gz = File::open(&output_filepath).unwrap();
             let tar = GzDecoder::new(tar_gz);

--- a/sources/logdog/src/main.rs
+++ b/sources/logdog/src/main.rs
@@ -12,6 +12,12 @@ Usage example:
 $ logdog
 logs are at: /tmp/bottlerocket-logs.tar.gz
 ```
+
+## TODO
+
+ [ ] journalctl-list-boots is instead errors
+ [x] dmesg not working
+ [ ] iptables missing
 */
 
 #![deny(rust_2018_idioms)]
@@ -142,7 +148,7 @@ fn create_commands() -> Vec<ExecToFile> {
         },
         ExecToFile {
             command: "dmesg",
-            args: vec!["--color", "never", "--nopager"],
+            args: vec!["--color=never", "--nopager"],
             output_filename: "dmesg",
         }
     )

--- a/sources/logdog/src/main.rs
+++ b/sources/logdog/src/main.rs
@@ -96,61 +96,73 @@ fn run_program(output: &PathBuf) -> Result<()> {
 /// Produces the list of commands that we will run on the Bottlerocket host.
 fn create_commands() -> Vec<ExecToFile> {
     vec![
+        // Get a copy of os-release to tell us the version and build of Bottlerocket.
         ExecToFile {
             command: "cat",
             args: vec!["/etc/os-release"],
             output_filename: "os-release",
         },
+        // Get a list of boots that journalctl knows about.
         ExecToFile {
             command: "journalctl",
             args: vec!["--list-boots", "--no-pager"],
             output_filename: "journalctl-list-boots",
         },
+        // Get errors only from journalctl.
         ExecToFile {
             command: "journalctl",
             args: vec!["-p", "err", "-a", "--no-pager"],
             output_filename: "journalctl.errors",
         },
+        // Get all log lines from journalctl.
         ExecToFile {
             command: "journalctl",
             args: vec!["-a", "--no-pager"],
             output_filename: "journalctl.log",
         },
+        // Get signpost status to tell us the status of grub and the boot partitions.
         ExecToFile {
             command: "signpost",
             args: vec!["status"],
             output_filename: "signpost",
         },
+        // Get Bottlerocket settings using the apiclient.
         ExecToFile {
             command: "apiclient",
             args: vec!["--method", "GET", "--uri", "/settings"],
             output_filename: "settings.json",
         },
+        // Get networking status with wicked.
         ExecToFile {
             command: "wicked",
             args: vec!["show", "all"],
             output_filename: "wicked",
         },
+        // Get configuration info from containerd.
         ExecToFile {
             command: "containerd",
             args: vec!["config", "dump"],
             output_filename: "containerd-config",
         },
+        // Get the status of kubelet and other kube processes from systemctl.
         ExecToFile {
             command: "systemctl",
             args: vec!["status", "kube*", "-l", "--no-pager"],
             output_filename: "kube-status",
         },
+        // Get the kernel message buffer with dmesg.
         ExecToFile {
             command: "dmesg",
             args: vec!["--color=never", "--nopager"],
             output_filename: "dmesg",
         },
+        // Get firewall filtering information with iptables.
         ExecToFile {
             command: "iptables",
             args: vec!["-nvL", "-t", "filter"],
             output_filename: "iptables-filter",
         },
+        // Get firewall nat information with iptables.
         ExecToFile {
             command: "iptables",
             args: vec!["-nvL", "-t", "nat"],

--- a/sources/logdog/src/temp_dir.rs
+++ b/sources/logdog/src/temp_dir.rs
@@ -1,11 +1,11 @@
 // Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: MIT OR Apache-2.0
 
-use std::fs::{remove_dir_all, create_dir_all};
+use std::fs::{create_dir_all, remove_dir_all};
 use std::path::PathBuf;
 
-/// Represents a self-cleaning (RAII) temporary directory. This is a simple inline implementation to
-/// avoid bringing in unnecessary dependencies.
+/// Represents a self-cleaning (RAII) temporary directory.
+/// This is a simple inline implementation to avoid bringing in unnecessary dependencies.
 pub(crate) struct TempDir {
     path_buf: PathBuf,
 }

--- a/sources/logdog/src/temp_dir.rs
+++ b/sources/logdog/src/temp_dir.rs
@@ -1,0 +1,58 @@
+// Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
+use std::fs::{remove_dir_all, create_dir_all};
+use std::path::PathBuf;
+
+/// Represents a self-cleaning (RAII) temporary directory. This is a simple inline implementation to
+/// avoid bringing in unnecessary dependencies.
+pub(crate) struct TempDir {
+    path_buf: PathBuf,
+}
+
+impl Drop for TempDir {
+    fn drop(&mut self) {
+        let result = remove_dir_all(&self.path_buf);
+        if result.is_err() {
+            println!(
+                "Could not delete directory '{}': {}",
+                self.path_buf.to_string_lossy(),
+                result.err().unwrap()
+            );
+        }
+    }
+}
+
+impl TempDir {
+    /// Creates the directory if it does not already exist.
+    pub(crate) fn new(path_buf: PathBuf) -> Result<TempDir, std::io::Error> {
+        create_dir_all(&path_buf)?;
+        Ok(TempDir { path_buf })
+    }
+
+    /// Gets the path.
+    pub(crate) fn path(&self) -> PathBuf {
+        self.path_buf.clone()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::path::Path;
+
+    use uuid::Uuid;
+
+    use super::*;
+
+    #[test]
+    fn test() {
+        let uuid = Uuid::new_v4().to_string();
+        let path_buf = std::env::temp_dir().join(uuid);
+        // Create a TempDir within a scope
+        {
+            let _temp_dir = TempDir::new(path_buf.clone()).unwrap();
+            assert!(Path::new(&path_buf).exists())
+        }
+        assert!(!Path::new(&path_buf).exists())
+    }
+}

--- a/sources/logdog/tests/tests.rs
+++ b/sources/logdog/tests/tests.rs
@@ -1,0 +1,9 @@
+// Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
+/// Test that something can do something
+#[test]
+fn test_something() {
+    // TODO - something for real
+    assert_eq!(1, 1);
+}

--- a/sources/logdog/tests/tests.rs
+++ b/sources/logdog/tests/tests.rs
@@ -1,9 +1,0 @@
-// Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
-// SPDX-License-Identifier: MIT OR Apache-2.0
-
-/// Test that something can do something
-#[test]
-fn test_something() {
-    // TODO - something for real
-    assert_eq!(1, 1);
-}


### PR DESCRIPTION
**Issue number:**

`bottlerocket-456`

**Description of changes:**

Creates a rust executable that shells out to multiple programs writing logs into an aggregation tempdir, then tars these and deletes the temps.

This is the prototype to get early feedback before getting in too deep with the design.

## Help

I could use some advice on how we want to approach documentation for this.

**Testing done:**

Built an ami with logdog bundled. SSH-ed to the admin container, used sudo sheltie, ran logdog, used SSH to retrieve the tar.gz file. Opened that file locally and it was good.

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
