### PR TITLE
Dns

### DIFF
--- a/sources/Cargo.lock
+++ b/sources/Cargo.lock
@@ -329,6 +329,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "781f336cc9826dbaddb9754cb5db61e64cab4f69668bd19dcc4a0394a86f4cb1"
 
 [[package]]
+name = "async-trait"
+version = "0.1.42"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8d3a45e77e34375a7923b1e8febb049bb011f064714a8e17a1a616fef01da13d"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "atty"
 version = "0.2.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -593,6 +604,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6245d59a3e82a7fc217c5828a6692dbc6dfb63a0c8c90495621f7b9d79704a0e"
 
 [[package]]
+name = "core-foundation"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0a89e2ae426ea83155dccf10c0fa6b1463ef6d5fcb44cee0b224a408fa640a62"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
+
+[[package]]
+name = "core-foundation-sys"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ea221b5284a47e40033bf9b66f35f984ec0ea2931eb03505246cd27a963f981b"
+
+[[package]]
 name = "corndog"
 version = "0.1.0"
 dependencies = [
@@ -651,6 +678,25 @@ dependencies = [
  "autocfg",
  "cfg-if 1.0.0",
  "lazy_static",
+]
+
+[[package]]
+name = "crypto-mac"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4857fd85a0c34b3c3297875b747c1e02e06b6a0ea32dd892d8192b9ce0813ea6"
+dependencies = [
+ "generic-array 0.14.4",
+ "subtle",
+]
+
+[[package]]
+name = "ct-logs"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c1a816186fa68d9e426e3cb4ae4dff1fcd8e4a2c34b781bf7a822574a0d0aac8"
+dependencies = [
+ "sct",
 ]
 
 [[package]]
@@ -732,6 +778,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d3dd60d1080a57a05ab032377049e0591415d2b31afd7028356dbf3cc6dcb066"
 dependencies = [
  "generic-array 0.14.4",
+]
+
+[[package]]
+name = "dirs-next"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b98cf8ebf19c3d1b223e151f99a4f9f0690dca41414773390fc824184ac833e1"
+dependencies = [
+ "cfg-if 1.0.0",
+ "dirs-sys-next",
+]
+
+[[package]]
+name = "dirs-sys-next"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4ebda144c4fe02d1f7ea1a7d9641b6fc6b580adcfa024ae48797ecdeb6825b4d"
+dependencies = [
+ "libc",
+ "redox_users",
+ "winapi",
 ]
 
 [[package]]
@@ -925,6 +992,7 @@ checksum = "7f55667319111d593ba876406af7c409c0ebb44dc4be6132a783ccf163ea14c1"
 dependencies = [
  "futures-channel",
  "futures-core",
+ "futures-executor",
  "futures-io",
  "futures-sink",
  "futures-task",
@@ -946,6 +1014,17 @@ name = "futures-core"
 version = "0.3.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "15496a72fabf0e62bdc3df11a59a3787429221dd0710ba8ef163d6f7a9112c94"
+
+[[package]]
+name = "futures-executor"
+version = "0.3.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "891a4b7b96d84d5940084b2a37632dd65deeae662c114ceaa2c879629c9c0ad1"
+dependencies = [
+ "futures-core",
+ "futures-task",
+ "futures-util",
+]
 
 [[package]]
 name = "futures-io"
@@ -1167,6 +1246,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5af1f635ef1bc545d78392b136bfe1c9809e029023c84a3638a864a10b8819c8"
 
 [[package]]
+name = "hmac"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c1441c6b1e930e2817404b5046f1f989899143a12bf92de603b69f4e0aee1e15"
+dependencies = [
+ "crypto-mac",
+ "digest 0.9.0",
+]
+
+[[package]]
 name = "host-containers"
 version = "0.1.0"
 dependencies = [
@@ -1269,10 +1358,12 @@ version = "0.22.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5f9f7a97316d44c0af9b0301e65010573a853a9fc97046d7331d7f6bc0fd5a64"
 dependencies = [
+ "ct-logs",
  "futures-util",
  "hyper",
  "log",
  "rustls",
+ "rustls-native-certs",
  "tokio",
  "tokio-rustls",
  "webpki",
@@ -1504,6 +1595,12 @@ name = "matches"
 version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7ffc5c5338469d4d3ea17d269fa8ea3512ad247247c30bd2df69e68309ed0a08"
+
+[[package]]
+name = "md5"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "490cc448043f947bae3cbee9c203358d62dbee0db12107a74be5c30ccfd09771"
 
 [[package]]
 name = "memchr"
@@ -1827,6 +1924,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "624a8340c38c1b80fd549087862da4ba43e08858af025b236e509b6649fc13d5"
 
 [[package]]
+name = "openssl-probe"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77af24da69f9d9341038eba93a073b1fdaaa1b788221b00a69bce9e762cb32de"
+
+[[package]]
 name = "parking_lot"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1986,11 +2089,15 @@ checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 name = "pluto"
 version = "0.1.0"
 dependencies = [
+ "apiclient",
  "cargo-readme",
  "lazy_static",
  "reqwest",
+ "rusoto_core",
+ "rusoto_eks",
  "serde_json",
  "snafu",
+ "tokio",
 ]
 
 [[package]]
@@ -2109,6 +2216,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "redox_users"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "528532f3d801c87aec9def2add9ca802fe569e44a544afe633765267840abe64"
+dependencies = [
+ "getrandom",
+ "redox_syscall",
+]
+
+[[package]]
 name = "regex"
 version = "1.4.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2194,6 +2311,89 @@ dependencies = [
 ]
 
 [[package]]
+name = "rusoto_core"
+version = "0.46.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "02aff20978970d47630f08de5f0d04799497818d16cafee5aec90c4b4d0806cf"
+dependencies = [
+ "async-trait",
+ "base64",
+ "bytes",
+ "crc32fast",
+ "futures",
+ "http",
+ "hyper",
+ "hyper-rustls",
+ "lazy_static",
+ "log",
+ "rusoto_credential",
+ "rusoto_signature",
+ "rustc_version",
+ "serde",
+ "serde_json",
+ "tokio",
+ "xml-rs",
+]
+
+[[package]]
+name = "rusoto_credential"
+version = "0.46.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e91e4c25ea8bfa6247684ff635299015845113baaa93ba8169b9e565701b58e"
+dependencies = [
+ "async-trait",
+ "chrono",
+ "dirs-next",
+ "futures",
+ "hyper",
+ "serde",
+ "serde_json",
+ "shlex",
+ "tokio",
+ "zeroize",
+]
+
+[[package]]
+name = "rusoto_eks"
+version = "0.46.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91d7e1e577d4102a9d80d5eafc0547064d3e8817d094f00e95ae45d03ae3accb"
+dependencies = [
+ "async-trait",
+ "bytes",
+ "futures",
+ "rusoto_core",
+ "serde",
+ "serde_derive",
+ "serde_json",
+]
+
+[[package]]
+name = "rusoto_signature"
+version = "0.46.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5486e6b1673ab3e0ba1ded284fb444845fe1b7f41d13989a54dd60f62a7b2baa"
+dependencies = [
+ "base64",
+ "bytes",
+ "futures",
+ "hex",
+ "hmac",
+ "http",
+ "hyper",
+ "log",
+ "md5",
+ "percent-encoding",
+ "pin-project-lite",
+ "rusoto_credential",
+ "rustc_version",
+ "serde",
+ "sha2",
+ "time 0.2.26",
+ "tokio",
+]
+
+[[package]]
 name = "rustc-demangle"
 version = "0.1.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2222,6 +2422,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustls-native-certs"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a07b7c1885bd8ed3831c289b7870b13ef46fe0e856d288c30d9cc17d75a2092"
+dependencies = [
+ "openssl-probe",
+ "rustls",
+ "schannel",
+ "security-framework",
+]
+
+[[package]]
 name = "rustversion"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2240,6 +2452,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
 dependencies = [
  "winapi-util",
+]
+
+[[package]]
+name = "schannel"
+version = "0.1.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f05ba609c234e60bee0d547fe94a4c7e9da733d1c962cf6e59efa4cd9c8bc75"
+dependencies = [
+ "lazy_static",
+ "winapi",
 ]
 
 [[package]]
@@ -2278,6 +2500,29 @@ checksum = "e3042af939fca8c3453b7af0f1c66e533a15a86169e39de2657310ade8f98d3c"
 dependencies = [
  "ring",
  "untrusted",
+]
+
+[[package]]
+name = "security-framework"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3670b1d2fdf6084d192bc71ead7aabe6c06aa2ea3fbd9cc3ac111fa5c2b1bd84"
+dependencies = [
+ "bitflags",
+ "core-foundation",
+ "core-foundation-sys",
+ "libc",
+ "security-framework-sys",
+]
+
+[[package]]
+name = "security-framework-sys"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3676258fd3cfe2c9a0ec99ce3038798d847ce3e4bb17746373eb9f0f1ac16339"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
 ]
 
 [[package]]
@@ -2442,6 +2687,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2579985fda508104f7587689507983eadd6a6e84dd35d6d115361f530916fa0d"
 
 [[package]]
+name = "sha2"
+version = "0.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fa827a14b29ab7f44778d14a88d3cb76e949c45083f7dbfa507d0cb699dc12de"
+dependencies = [
+ "block-buffer 0.9.0",
+ "cfg-if 1.0.0",
+ "cpuid-bool",
+ "digest 0.9.0",
+ "opaque-debug 0.3.0",
+]
+
+[[package]]
 name = "shared-containerd-configs"
 version = "0.1.0"
 dependencies = [
@@ -2469,6 +2727,12 @@ dependencies = [
  "simplelog",
  "snafu",
 ]
+
+[[package]]
+name = "shlex"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7fdf1b9db47230893d76faad238fd6097fd6d6a9245cd7a4d90dbd639536bbd2"
 
 [[package]]
 name = "signal-hook"
@@ -2704,6 +2968,12 @@ dependencies = [
  "quote",
  "syn",
 ]
+
+[[package]]
+name = "subtle"
+version = "2.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e81da0851ada1f3e9d4312c704aa4f8806f0f9d69faaf8df2f3464b4a9437c2"
 
 [[package]]
 name = "sundog"
@@ -3355,3 +3625,9 @@ name = "xml-rs"
 version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b07db065a5cf61a7e4ba64f29e67db906fb1787316516c4e6e5ff0fea1efcd8a"
+
+[[package]]
+name = "zeroize"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "81a974bcdd357f0dca4d41677db03436324d45a4c9ed2d0b873a5a360ce41c36"

--- a/sources/api/pluto/Cargo.toml
+++ b/sources/api/pluto/Cargo.toml
@@ -10,10 +10,14 @@ build = "build.rs"
 exclude = ["README.md"]
 
 [dependencies]
+apiclient = { path = "../apiclient" }
 lazy_static = "1.4"
-reqwest = { version = "0.11.1", default-features = false, features = ["blocking"]}
+reqwest = { version = "0.11.1", default-features = false }
+rusoto_core = { version = "0.46", default-features = false, features = ["rustls"] }
+rusoto_eks = { version = "0.46", default-features = false, features = ["rustls"] }
 serde_json = "1"
-snafu = "0.6"
+snafu = { version = "0.6", features = [ "futures" ] }
+tokio = { version = "1", default-features = false, features = ["macros", "rt-multi-thread"] }
 
 [build-dependencies]
 cargo-readme = "3.1"

--- a/sources/api/pluto/README.md
+++ b/sources/api/pluto/README.md
@@ -6,13 +6,32 @@ Current version: 0.1.0
 
 pluto is called by sundog to generate settings required by Kubernetes.
 This is done dynamically because we require access to dynamic networking
-setup information.
+and cluster setup information.
 
-It makes calls to IMDS to get meta data:
+It uses IMDS to get information such as:
 
-- Cluster DNS
+- Instance Type
 - Node IP
 - POD Infra Container Image
+
+It uses EKS to get information such as:
+
+- Service IPV4 CIDR
+
+It makes calls to the Bottlerocket API to get information such as:
+
+- Kubernetes Cluster Name
+
+## Interface
+
+Pluto takes the name of the setting that it is to generate as its first
+argument.
+It returns the generated setting to stdout as a JSON document.
+Any other output is returned to stderr.
+
+Pluto returns a special exit code of 2 to inform `sundog` that a setting should be skipped. For
+example, if `max-pods` cannot be generated, we want `sundog` to skip it without failing since a
+reasonable default is available.
 
 ## Colophon 
 

--- a/sources/api/pluto/src/api.rs
+++ b/sources/api/pluto/src/api.rs
@@ -1,0 +1,60 @@
+use snafu::{OptionExt, ResultExt, Snafu};
+
+// FIXME Get these from configuration in the future
+const DEFAULT_API_SOCKET: &str = "/run/api.sock";
+const CLUSTER_NAME_URI: &str = "/settings?keys=settings.kubernetes.cluster-name";
+
+#[derive(Debug, Snafu)]
+pub(super) enum Error {
+    #[snafu(display("Error calling Bottlerocket API: {}", source))]
+    ApiClientError {
+        source: apiclient::Error,
+        uri: String,
+    },
+
+    #[snafu(display("The 'cluster-name' setting is missing"))]
+    ClusterNameMissing {},
+
+    #[snafu(display("The 'cluster-name' setting is not a string"))]
+    ClusterNameType {},
+
+    #[snafu(display("Kubernetes settings are missing"))]
+    KubernetesKey {},
+
+    #[snafu(display("Kubernetes settings are not a JSON object"))]
+    KubernetesObject {},
+
+    #[snafu(display("API response was not a JSON object"))]
+    ResponseObject {},
+
+    #[snafu(display("Unable to parse Bottlerocket API response as JSON: {}", source))]
+    ResponseJsonParse { source: serde_json::Error },
+}
+
+/// The result type for the [`api`] module.
+pub(super) type Result<T> = std::result::Result<T, Error>;
+
+/// Gets the Kubernetes cluster name from the Bottlerocket API.
+pub(super) async fn get_cluster_name() -> Result<String> {
+    let (_, raw_response) =
+        apiclient::raw_request(DEFAULT_API_SOCKET, CLUSTER_NAME_URI, "GET", None)
+            .await
+            .context(ApiClientError {
+                uri: CLUSTER_NAME_URI,
+            })?;
+    let parsed_response: serde_json::Value =
+        serde_json::from_str(&raw_response).context(ResponseJsonParse)?;
+
+    Ok(parsed_response
+        .as_object()
+        .context(ResponseObject)?
+        .get("kubernetes")
+        .context(KubernetesKey)?
+        .as_object()
+        .context(KubernetesObject)?
+        .get("cluster-name")
+        .context(ClusterNameMissing)?
+        .as_str()
+        .context(ClusterNameType)?
+        .to_owned())
+}

--- a/sources/api/pluto/src/eks.rs
+++ b/sources/api/pluto/src/eks.rs
@@ -1,0 +1,50 @@
+use rusoto_core::region::ParseRegionError;
+use rusoto_core::{Region, RusotoError};
+use rusoto_eks::{DescribeClusterError, Eks as RusotoEks, EksClient};
+use snafu::{OptionExt, ResultExt, Snafu};
+use std::str::FromStr;
+
+#[derive(Debug, Snafu)]
+pub(super) enum Error {
+    #[snafu(display("Error describing cluster: {}", source))]
+    DescribeCluster {
+        source: RusotoError<DescribeClusterError>,
+    },
+
+    #[snafu(display("Cluster object is missing from EKS response"))]
+    MissingCluster {},
+
+    #[snafu(display("kubernetes_network_config is missing the service_ipv_4_cidr field"))]
+    MissingIpv4Cidr {},
+
+    #[snafu(display("Cluster object is missing the kubernetes_network_config field"))]
+    MissingNetworkConfig {},
+
+    #[snafu(display("Unable to parse '{}' as a region: {}", region, source))]
+    RegionParse {
+        region: String,
+        source: ParseRegionError,
+    },
+}
+
+type Result<T> = std::result::Result<T, Error>;
+
+/// Returns the cluster's [serviceIPv4CIDR] DNS IP by calling the EKS API.
+/// (https://docs.aws.amazon.com/eks/latest/APIReference/API_KubernetesNetworkConfigRequest.html)
+pub(super) async fn get_cluster_cidr(region: &str, cluster: &str) -> Result<String> {
+    let parsed_region = Region::from_str(region).context(RegionParse { region })?;
+    let client = EksClient::new(parsed_region);
+    let describe_cluster = rusoto_eks::DescribeClusterRequest {
+        name: cluster.to_owned(),
+    };
+    client
+        .describe_cluster(describe_cluster)
+        .await
+        .context(DescribeCluster {})?
+        .cluster
+        .context(MissingCluster)?
+        .kubernetes_network_config
+        .context(MissingNetworkConfig)?
+        .service_ipv_4_cidr
+        .context(MissingIpv4Cidr)
+}

--- a/sources/api/pluto/src/main.rs
+++ b/sources/api/pluto/src/main.rs
@@ -5,24 +5,47 @@
 
 pluto is called by sundog to generate settings required by Kubernetes.
 This is done dynamically because we require access to dynamic networking
-setup information.
+and cluster setup information.
 
-It makes calls to IMDS to get meta data:
+It uses IMDS to get information such as:
 
-- Cluster DNS
+- Instance Type
 - Node IP
 - POD Infra Container Image
+
+It uses EKS to get information such as:
+
+- Service IPV4 CIDR
+
+It makes calls to the Bottlerocket API to get information such as:
+
+- Kubernetes Cluster Name
+
+# Interface
+
+Pluto takes the name of the setting that it is to generate as its first
+argument.
+It returns the generated setting to stdout as a JSON document.
+Any other output is returned to stderr.
+
+Pluto returns a special exit code of 2 to inform `sundog` that a setting should be skipped. For
+example, if `max-pods` cannot be generated, we want `sundog` to skip it without failing since a
+reasonable default is available.
 */
 
+mod api;
+mod eks;
+
+use crate::eks::get_cluster_cidr;
+use error::PlutoError;
 use lazy_static::lazy_static;
-use reqwest::blocking::Client;
+use reqwest::Client;
+use snafu::{ensure, OptionExt, ResultExt};
 use std::collections::HashMap;
 use std::fs::File;
 use std::io::{BufRead, BufReader};
 use std::string::String;
 use std::{env, process};
-
-use snafu::{OptionExt, ResultExt};
 
 // This is the default DNS unless our CIDR block begins with "10."
 const DEFAULT_DNS_CLUSTER_IP: &str = "10.100.0.10";
@@ -83,7 +106,8 @@ lazy_static! {
 const PAUSE_FALLBACK_ACCOUNT: &str = "602401143452";
 const PAUSE_FALLBACK_REGION: &str = "us-east-1";
 
-mod error {
+pub(crate) mod error {
+    use crate::api;
     use snafu::Snafu;
 
     // Taken from sundog.
@@ -99,6 +123,12 @@ mod error {
     #[derive(Debug, Snafu)]
     #[snafu(visibility = "pub(super)")]
     pub(super) enum PlutoError {
+        #[snafu(display("Unable to parse CIDR '{}'", cidr))]
+        CidrParse { cidr: String },
+
+        #[snafu(display("Unable to get cluster name from Bottlerocket API: {}", source))]
+        ClusterName { source: api::Error },
+
         #[snafu(display("Error {}ing '{}': {}", method, uri, source))]
         ImdsRequest {
             method: String,
@@ -163,24 +193,25 @@ mod error {
     }
 }
 
-use error::PlutoError;
+pub(crate) type Result<T> = std::result::Result<T, PlutoError>;
 
-type Result<T> = std::result::Result<T, PlutoError>;
-
-fn get_text_from_imds(client: &Client, uri: &str, session_token: &str) -> Result<String> {
+async fn get_text_from_imds(client: &Client, uri: &str, session_token: &str) -> Result<String> {
     client
         .get(uri)
         .header("X-aws-ec2-metadata-token", session_token)
         .send()
+        .await
         .context(error::ImdsRequest { method: "GET", uri })?
         .error_for_status()
         .context(error::ImdsResponse { uri })?
         .text()
+        .await
         .context(error::ImdsText { uri })
 }
 
-fn get_max_pods(client: &Client, session_token: &str) -> Result<String> {
-    let instance_type = get_text_from_imds(&client, IMDS_INSTANCE_TYPE_ENDPOINT, session_token)?;
+async fn get_max_pods(client: &Client, session_token: &str) -> Result<String> {
+    let instance_type =
+        get_text_from_imds(&client, IMDS_INSTANCE_TYPE_ENDPOINT, session_token).await?;
     // Find the corresponding maximum number of pods supported by this instance type
     let file = BufReader::new(
         File::open(ENI_MAX_PODS_PATH).context(error::EniMaxPodsFile {
@@ -201,9 +232,64 @@ fn get_max_pods(client: &Client, session_token: &str) -> Result<String> {
     error::NoInstanceTypeMaxPods { instance_type }.fail()
 }
 
-fn get_cluster_dns_ip(client: &Client, session_token: &str) -> Result<String> {
+/// Returns the cluster's DNS IPV4 address. First it attempts to call EKS describe-cluster to find
+/// the `serviceIPv4CIDR`. If that works, it returns the first `*.10` address. If the EKS call is
+/// not successful, it falls back to using IMDS MAC CIDR blocks to return one of two default
+/// addresses.
+async fn get_cluster_dns_ip(client: &Client, session_token: &str) -> Result<String> {
+    let region = get_region(client, session_token).await?;
+    let cluster_name = api::get_cluster_name()
+        .await
+        .context(error::ClusterName {})?;
+
+    // try calling eks describe-cluster to figure out the dns cluster ip
+    if let Some(dns_ip) = get_dns_from_eks(&region, &cluster_name).await {
+        // we were able to calculate the dns ip from the cidr range we received from eks
+        return Ok(dns_ip);
+    }
+
+    // we were unable to obtain or parse the cidr range from eks, fallback to one of two default
+    // values based on the cidr range of our primary network interface
+    get_cluster_dns_from_imds_mac(client, session_token).await
+}
+
+/// Gets the Service IPV4 CIDR setting from EKS and parses it to calculate the cluster DNS IP.
+/// Prints the error and returns `None` if anything goes wrong.
+async fn get_dns_from_eks(region: &str, cluster_name: &str) -> Option<String> {
+    let cidr = match get_cluster_cidr(region, cluster_name).await {
+        Ok(cidr) => cidr,
+        Err(e) => {
+            eprintln!("Unable to get CIDR from EKS, using default DNS IP: {}", e);
+            return None;
+        }
+    };
+    match get_dns_from_cidr(&cidr) {
+        Ok(dns_ip) => Some(dns_ip),
+        Err(e) => {
+            eprintln!("Unable to parse CIDR from EKS, using default DNS IP: {}", e);
+            None
+        }
+    }
+}
+
+/// Replicates [this] logic from the EKS AMI:
+///
+/// ```sh
+/// DNS_CLUSTER_IP=${SERVICE_IPV4_CIDR%.*}.10
+/// ```
+/// [this]: https://github.com/awslabs/amazon-eks-ami/blob/732b6b2/files/bootstrap.sh#L335
+fn get_dns_from_cidr(cidr: &str) -> Result<String> {
+    let mut split: Vec<&str> = cidr.split('.').collect();
+    ensure!(split.len() == 4, error::CidrParse { cidr });
+    split[3] = "10";
+    Ok(split.join(".").into())
+}
+
+/// Gets gets the the first VPC IPV4 CIDR block from IMDS. If it starts with `10`, returns
+/// `10.100.0.10`, otherwise returns `172.20.0.10`
+async fn get_cluster_dns_from_imds_mac(client: &Client, session_token: &str) -> Result<String> {
     let uri = IMDS_MAC_ENDPOINT;
-    let macs = get_text_from_imds(&client, uri, session_token)?;
+    let macs = get_text_from_imds(&client, uri, session_token).await?;
     // Take the first (primary) MAC address. Others will exist from attached ENIs.
     let mac = macs.split('\n').next().context(error::MissingMac { uri })?;
 
@@ -212,7 +298,7 @@ fn get_cluster_dns_ip(client: &Client, session_token: &str) -> Result<String> {
         "{}/meta-data/network/interfaces/macs/{}/vpc-ipv4-cidr-blocks",
         IMDS_BASE_URL, mac
     );
-    let mac_cidr_blocks = get_text_from_imds(&client, &mac_cidr_blocks_uri, session_token)?;
+    let mac_cidr_blocks = get_text_from_imds(&client, &mac_cidr_blocks_uri, session_token).await?;
 
     let dns = if mac_cidr_blocks.starts_with("10.") {
         DEFAULT_10_RANGE_DNS_CLUSTER_IP
@@ -220,25 +306,28 @@ fn get_cluster_dns_ip(client: &Client, session_token: &str) -> Result<String> {
         DEFAULT_DNS_CLUSTER_IP
     }
     .to_string();
-
     Ok(dns)
 }
 
-fn get_node_ip(client: &Client, session_token: &str) -> Result<String> {
-    get_text_from_imds(&client, IMDS_NODE_IPV4_ENDPOINT, session_token)
+async fn get_node_ip(client: &Client, session_token: &str) -> Result<String> {
+    get_text_from_imds(&client, IMDS_NODE_IPV4_ENDPOINT, session_token).await
 }
 
-fn get_pod_infra_container_image(client: &Client, session_token: &str) -> Result<String> {
+async fn get_region(client: &Client, session_token: &str) -> Result<String> {
     // Get the region from the correct location.
     let uri = IMDS_INSTANCE_IDENTITY_DOCUMENT_ENDPOINT;
-    let iid_text = get_text_from_imds(&client, uri, session_token)?;
+    let iid_text = get_text_from_imds(&client, uri, session_token).await?;
     let iid_json: serde_json::Value =
         serde_json::from_str(&iid_text).context(error::ImdsJson { uri })?;
-    let region = iid_json["region"]
+    iid_json["region"]
         .as_str()
-        .context(error::MissingRegion { uri })?;
+        .map(|s| s.to_owned())
+        .context(error::MissingRegion { uri })
+}
 
-    pause_container_uri(region)
+async fn get_pod_infra_container_image(client: &Client, session_token: &str) -> Result<String> {
+    let region = get_region(client, session_token).await?;
+    pause_container_uri(&region)
 }
 
 /// Returns the machine architecture.
@@ -285,30 +374,36 @@ fn parse_args(mut args: env::Args) -> String {
     args.nth(1).unwrap_or_else(|| usage())
 }
 
-fn run() -> Result<()> {
+async fn run() -> Result<()> {
     let setting_name = parse_args(env::args());
-
     let client = Client::new();
+
     // Use IMDSv2 for accessing instance metadata
     let uri = IMDS_SESSION_TOKEN_ENDPOINT;
     let imds_session_token = client
         .put(uri)
         .header("X-aws-ec2-metadata-token-ttl-seconds", "60")
         .send()
+        .await
         .context(error::ImdsRequest { method: "PUT", uri })?
         .error_for_status()
         .context(error::ImdsResponse { uri })?
         .text()
+        .await
         .context(error::ImdsText { uri })?;
 
     let setting = match setting_name.as_ref() {
-        "cluster-dns-ip" => get_cluster_dns_ip(&client, &imds_session_token),
-        "node-ip" => get_node_ip(&client, &imds_session_token),
-        "pod-infra-container-image" => get_pod_infra_container_image(&client, &imds_session_token),
+        "cluster-dns-ip" => get_cluster_dns_ip(&client, &imds_session_token).await,
+        "node-ip" => get_node_ip(&client, &imds_session_token).await,
+        "pod-infra-container-image" => {
+            get_pod_infra_container_image(&client, &imds_session_token).await
+        }
 
         // If we want to specify a reasonable default in a template, we can exit 2 to tell
         // sundog to skip this setting.
-        "max-pods" => get_max_pods(&client, &imds_session_token).map_err(|_| process::exit(2)),
+        "max-pods" => get_max_pods(&client, &imds_session_token)
+            .await
+            .map_err(|_| process::exit(2)),
 
         _ => usage(),
     }?;
@@ -336,16 +431,17 @@ fn run() -> Result<()> {
 // Returning a Result from main makes it print a Debug representation of the error, but with Snafu
 // we have nice Display representations of the error, so we wrap "main" (run) and print any error.
 // https://github.com/shepmaster/snafu/issues/110
-fn main() {
-    if let Err(e) = run() {
+#[tokio::main]
+async fn main() {
+    if let Err(e) = run().await {
         eprintln!("{}", e);
         process::exit(1);
     }
 }
 
 #[cfg(test)]
-mod test_pause_container_account {
-    use super::{arch, pause_container_uri, PAUSE_CONTAINER_VERSION};
+mod test {
+    use super::*;
 
     #[test]
     fn url_eu_west_1() {
@@ -381,5 +477,20 @@ mod test_pause_container_account {
                 PAUSE_CONTAINER_VERSION
             )
         );
+    }
+
+    #[test]
+    fn test_get_dns_from_cidr_ok() {
+        let input = "123.456.789.0/123";
+        let expected = "123.456.789.10";
+        let actual = get_dns_from_cidr(input).unwrap();
+        assert_eq!(expected, actual);
+    }
+
+    #[test]
+    fn test_get_dns_from_cidr_err() {
+        let input = "123_456_789_0/123";
+        let result = get_dns_from_cidr(input);
+        assert!(result.is_err());
     }
 }


### PR DESCRIPTION
## Issue number:

The Cluster DNS Issue.

## Description of changes:

We previously assumed that an EKS cluster DNS IP was either 10.100.0.10 or 172.20.0.10. This may be incorrect when the cluster has a custom serviceIPv4CIDR setting.

Now we get the serviceIPv4CIDR from EKS describe-cluster so that we can calculate the correct cluster DNS IP in the presence of serviceIPv4CIDR.

Notes 
- this requires rusoto v0.46 because the serviceIPv4CIDR is fairly new to the API 
- rusoto v0.46 relies on tokio v1
- We needed to switch from `reqwest::blocking` to `reqwest` async for the IMDS calls because we need a runtime for rusoto.

## Testing done:

#### Reproducing the issue before fixing it:

After reading [this](https://unofficial-kubernetes.readthedocs.io/en/latest/concepts/services-networking/dns-pod-service/)

- I created a cluster with a custom CIDR: `10.31.32.0/24`.
- I ran a production 1.18 AMI and verified that it had the wrong Cluster DNS: `10.100.0.10`.
- I ran a pod like this (there was some nslookup bug with busybox so I used ubuntu and installed dnsutils on the healthy pod. I couldn't apt-get install anything on the unhealthy pod which further proves DNS was broken. For the unhealthy pod I used busybox):
  - `kubectl run -i -t ubuntu --image=ubuntu --restart=Never --command=true -- bash`
- Inside the pod I ran `nslookup kubernetes.default`, which returned

```
/ # nslookup kubernetes.default
;; connection timed out; no servers could be reached
```

In a healthy, non-custom-CIDR cluster, the above produces:

```
root@ubuntu:/# nslookup kubernetes.default
Server:   10.100.0.10
Address:  10.100.0.10#53

Name: kubernetes.default.svc.cluster.local
Address: 10.100.0.1
```

Thus we have proven that Bottlerocket does not work correctly with a custom `serviceIPv4CIDR`.

#### Testing this PR

**Custom CIDR Cluster**

- I ran a node in a cluster with `serviceIPv4CIDR: '10.31.32.0/24'`
- I logged in and checked the Cluster DNS IP
  - `apiclient -u /settings?keys=settings.kubernetes.cluster-dns-ip`
  - `{"kubernetes":{"cluster-dns-ip":"10.31.32.10"}}`
- I ran a pod:
  - `kubectl run -i -t ubuntu --image=ubuntu --restart=Never --command=true -- bash`
  - `nslookup kubernetes.default`

The result shows that cluster DNS resolution is working:

```text
Server:   10.31.32.10
Address:  10.31.32.10#53

Name: kubernetes.default.svc.cluster.local
Address: 10.31.32.1
```

**Non-Custom CIDR Cluster**

- I ran a node in a cluster with no `serviceIPv4CIDR` configuration.
- I logged in and checked the Cluster DNS IP
  - `apiclient -u /settings?keys=settings.kubernetes.cluster-dns-ip`
  - `{"kubernetes":{"cluster-dns-ip":"10.100.0.10"}}`
- I ran a pod:
  - `kubectl run -i -t ubuntu --image=ubuntu --restart=Never --command=true -- bash`
  - `nslookup kubernetes.default`

The result shows that cluster DNS resolution is working:

```text
Server:   10.100.0.10
Address:  10.100.0.10#53

Name: kubernetes.default.svc.cluster.local
Address: 10.100.0.1
```

**Without Describe Cluster Permissions**

- I ran a node in a cluster with no `serviceIPv4CIDR` configuration and with DescribeCluster removed from the Node's instance role.
- I logged in and checked some tracing in the journal.
  - Saw this: `Unable to determine CIDR from EKS, falling back to default cluster DNS IP: Error describing cluster: Request ID: Some("9753370c-9443-455c-91b4-a182491bcf1e") Body: {"message":"User: arn:aws:sts::xxx:assumed-role/ [...] is not authorized to perform: eks:DescribeCluster on resource: [..."}`
  - `apiclient -u /settings?keys=settings.kubernetes.cluster-dns-ip`
  - `{"kubernetes":{"cluster-dns-ip":"10.100.0.10"}}`
- I ran a pod:
  - `kubectl run -i -t ubuntu --image=ubuntu --restart=Never --command=true -- bash`
  - `nslookup kubernetes.default`

The result shows that cluster DNS resolution is working despite failure to call the EKS API and describe-cluster:

```text
Server:   10.100.0.10
Address:  10.100.0.10#53

Name: kubernetes.default.svc.cluster.local
Address: 10.100.0.1
```

## Terms of contribution:

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
