### PR TITLE
pubsys: validate-repo without tokio runtime

### DIFF
--- a/tools/pubsys/src/main.rs
+++ b/tools/pubsys/src/main.rs
@@ -44,12 +44,7 @@ fn run() -> Result<()> {
     match args.subcommand {
         SubCommand::Repo(ref repo_args) => repo::run(&args, &repo_args).context(error::Repo),
         SubCommand::ValidateRepo(ref validate_repo_args) => {
-            let rt = Runtime::new().context(error::Runtime)?;
-            rt.block_on(async {
-                repo::validate_repo::run(&args, &validate_repo_args)
-                    .await
-                    .context(error::ValidateRepo)
-            })
+            repo::validate_repo::run(&args, &validate_repo_args).context(error::ValidateRepo)
         }
         SubCommand::CheckRepoExpirations(ref check_expirations_args) => {
             repo::check_expirations::run(&args, &check_expirations_args)


### PR DESCRIPTION
Re-implement the parallelism of pubsys validate-repo so that it does not
need a tokio runtime. The runtime was interfering with the runtime
created by reqwest::blocking.

<!--
Tips:
- Please read CONTRIBUTING.md to understand our process and our requests for PRs.
- Please file an issue before creating a PR so we can discuss the change and confirm it's not already being worked on.
-->

**Issue number:**



**Description of changes:**



**Testing done:**



**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
